### PR TITLE
Fix step name in CI workflow

### DIFF
--- a/.github/workflows/ci-in-devcontainer.yml
+++ b/.github/workflows/ci-in-devcontainer.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Export
+      - name: Build in DevContainer
         uses: devcontainers/ci@v0.3
         with:
           cacheFrom: k-taro56/population-trends-graph-devcontainer


### PR DESCRIPTION
This pull request fixes the step name in the CI workflow file `ci-in-devcontainer.yml`. The step name was changed from "Export" to "Build in DevContainer" to better reflect its purpose. This change improves the clarity and readability of the workflow.