### PR TITLE
Add test for displaying message when no prefecture is selected

### DIFF
--- a/tests/app/page.test.tsx
+++ b/tests/app/page.test.tsx
@@ -27,4 +27,20 @@ describe('Home component', () => {
       expect(screen.getByText('Tokyo')).toBeInTheDocument();
     });
   });
+
+  it('displays message when no prefecture is selected', async () => {
+    const mockPrefectures = [{ prefCode: 1, prefName: 'Tokyo' }];
+    (usePrefectures as jest.Mock).mockReturnValue({ data: mockPrefectures });
+    (usePopulationCompositions as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+
+    render(<Home />);
+    await waitFor(() => {
+      expect(
+        screen.getByText('都道府県を選択してください。'),
+      ).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
This pull request adds a new test to the Home component. The test ensures that a message is displayed when no prefecture is selected.