### PR TITLE
Refactor getChartOptions parameter to use object

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,11 +32,11 @@ export default function Home() {
     );
   };
 
-  const chartOptions = getChartOptions(
+  const chartOptions = getChartOptions({
     populationCompositions,
     selectedPrefectures,
     label,
-  );
+  });
 
   useEffect(() => {
     if (populationCompositions?.[0] && !label) {

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -2,11 +2,15 @@ import type { SeriesOptionsType } from 'highcharts';
 
 import type { PopulationComposition, Prefecture } from '@/types';
 
-export const getChartOptions = (
-  populationCompositions: PopulationComposition[] | undefined,
-  selectedPrefectures: Prefecture[],
-  label: string,
-) => {
+export const getChartOptions = ({
+  populationCompositions,
+  selectedPrefectures,
+  label,
+}: {
+  populationCompositions: PopulationComposition[] | undefined;
+  selectedPrefectures: Prefecture[];
+  label: string;
+}) => {
   const series: SeriesOptionsType[] =
     populationCompositions?.map((populationComposition, index) => {
       const selectedPrefecture = selectedPrefectures[index];

--- a/tests/utils/chart.test.ts
+++ b/tests/utils/chart.test.ts
@@ -37,11 +37,11 @@ describe('getChartOptions', () => {
   it('should return correct chart options', () => {
     const label = '総人口';
 
-    const result = getChartOptions(
-      mockPopulationCompositions,
+    const result = getChartOptions({
+      populationCompositions: mockPopulationCompositions,
       selectedPrefectures,
       label,
-    );
+    });
 
     expect(result).toEqual({
       title: { text: '都道府県別の総人口推移' },
@@ -69,7 +69,11 @@ describe('getChartOptions', () => {
   });
 
   it('should return empty series when populationCompositions is undefined', () => {
-    const result = getChartOptions(undefined, [hokkaido, aomori], '総人口');
+    const result = getChartOptions({
+      populationCompositions: undefined,
+      selectedPrefectures,
+      label: '総人口',
+    });
     expect(result.series).toEqual([]);
   });
 });


### PR DESCRIPTION
This pull request refactors the `getChartOptions` function to use an object as a parameter instead of individual arguments. This improves readability and makes the function more flexible for future changes.