### PR TITLE
Add vscode-jest extension to devcontainer and recommendations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,11 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
       },
-      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "orta.vscode-jest"
+      ]
     }
   }
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "orta.vscode-jest"
+  ]
 }


### PR DESCRIPTION
This pull request adds the vscode-jest extension to the devcontainer.json file and the extensions.json file. This allows developers to easily run and debug Jest tests directly from Visual Studio Code. The vscode-jest extension provides features such as test discovery, test debugging, and test coverage. With this addition, developers can have a seamless testing experience within the development container.