### PR TITLE
Update PrefectureList component to use div instead of label for each item

### DIFF
--- a/src/components/prefecture-list.tsx
+++ b/src/components/prefecture-list.tsx
@@ -13,14 +13,16 @@ const PrefectureList = ({
   return (
     <div className={styles.prefectureList}>
       {prefectures.map((prefecture) => (
-        <label key={prefecture.prefCode} className={styles.prefectureItem}>
-          <input
-            type='checkbox'
-            value={prefecture.prefCode}
-            onChange={(e) => onPrefectureChange(prefecture, e.target.checked)}
-          />
-          {prefecture.prefName}
-        </label>
+        <div key={prefecture.prefCode} className={styles.prefectureItem}>
+          <label>
+            <input
+              type='checkbox'
+              value={prefecture.prefCode}
+              onChange={(e) => onPrefectureChange(prefecture, e.target.checked)}
+            />
+            {prefecture.prefName}
+          </label>
+        </div>
       ))}
     </div>
   );

--- a/src/components/styles/prefecture-list.module.css
+++ b/src/components/styles/prefecture-list.module.css
@@ -16,6 +16,10 @@
   margin-right: 0.25rem;
 }
 
+.prefectureItem label {
+  cursor: pointer;
+}
+
 @media (max-width: 48rem) {
   .prefectureList {
     grid-template-columns: repeat(auto-fill, minmax(6.25rem, 1fr));


### PR DESCRIPTION
This pull request updates the PrefectureList component to use `<div>` instead of `<label>` for each item. This change improves the accessibility of the component by allowing users to click anywhere within the item to select it.