### PR TITLE
Update getChartOptions function to include boundary year and dashed line for estimated data

### DIFF
--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -11,7 +11,7 @@ export const getChartOptions = ({
   selectedPrefectures: Prefecture[];
   label: string;
 }) => {
-  const series: SeriesOptionsType[] =
+  const series =
     populationCompositions?.map((populationComposition, index) => {
       const selectedPrefecture = selectedPrefectures[index];
       return {
@@ -20,11 +20,23 @@ export const getChartOptions = ({
         data: populationComposition.data
           .find((populationTrends) => populationTrends.label === label)
           ?.data.map((item) => [item.year, item.value]),
-      };
+        zoneAxis: 'x',
+        zones: [
+          {
+            value: populationComposition.boundaryYear,
+          },
+          {
+            dashStyle: 'Dot',
+          },
+        ],
+      } satisfies SeriesOptionsType;
     }) || [];
 
   return {
     title: { text: `都道府県別の${label}推移` },
+    subtitle: {
+      text: '破線は推計値',
+    },
     xAxis: { title: { text: '年度' } },
     yAxis: { title: { text: '人口数' } },
     series,

--- a/tests/utils/chart.test.ts
+++ b/tests/utils/chart.test.ts
@@ -45,6 +45,7 @@ describe('getChartOptions', () => {
 
     expect(result).toEqual({
       title: { text: '都道府県別の総人口推移' },
+      subtitle: { text: '破線は推計値' },
       xAxis: { title: { text: '年度' } },
       yAxis: { title: { text: '人口数' } },
       series: [
@@ -55,6 +56,15 @@ describe('getChartOptions', () => {
             [2015, 5381733],
             [2020, 5224614],
           ],
+          zoneAxis: 'x',
+          zones: [
+            {
+              value: 2020,
+            },
+            {
+              dashStyle: 'Dot',
+            },
+          ],
         },
         {
           type: 'line',
@@ -62,6 +72,15 @@ describe('getChartOptions', () => {
           data: [
             [2015, 1308265],
             [2020, 1237984],
+          ],
+          zoneAxis: 'x',
+          zones: [
+            {
+              value: 2020,
+            },
+            {
+              dashStyle: 'Dot',
+            },
           ],
         },
       ],


### PR DESCRIPTION
This pull request updates the `getChartOptions` function in the `chart.ts` file to include a boundary year and a dashed line for estimated data. It also adds a subtitle to the chart indicating that the dashed line represents estimated values. The changes are tested in the `chart.test.ts` file.