### PR TITLE
Update vercel.json with $schema link for OpenAPI validation

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "cleanUrls": true,
   "framework": "nextjs",
   "installCommand": "pnpm install --frozen-lockfile --ignore-scripts"


### PR DESCRIPTION
This pull request updates the `vercel.json` file to include a `$schema` link for OpenAPI validation. This will ensure that the file adheres to the OpenAPI specification and can be validated against it.