### PR TITLE
Add "regions" field to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "cleanUrls": true,
   "framework": "nextjs",
-  "installCommand": "pnpm install --frozen-lockfile --ignore-scripts"
+  "installCommand": "pnpm install --frozen-lockfile --ignore-scripts",
+  "regions": ["hnd1"]
 }


### PR DESCRIPTION
This pull request adds a new "regions" field to the vercel.json file for deployment region configuration. Previously, the file only contained fields for cleanUrls, framework, and installCommand. The "regions" field allows specifying the desired deployment region, and in this case, it is set to "hnd1". This change ensures that the application is deployed to the specified region.