### PR TITLE
Update pre-commit script to use lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm lint-staged
+lint-staged


### PR DESCRIPTION
This pull request updates the pre-commit script to use lint-staged instead of pnpm. This change improves the efficiency and consistency of the linting process.